### PR TITLE
combined-clj-cljs repl type

### DIFF
--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -169,7 +169,15 @@
                  (ns-vars . "(clojure.repl/dir %s)")
                  (set-ns . "(clojure.core/in-ns '%s)")
                  (macroexpand . "(clojure.core/macroexpand '%s)")
-                 (macroexpand-1 . "(clojure.core/macroexpand-1 '%s)")))))
+                 (macroexpand-1 . "(clojure.core/macroexpand-1 '%s)")))
+    (combined-clj-cljs . ((doc . "(-> \"%s\" #?(:default clojure.repl/doc :cljs cljs.repl/doc))")
+                          (source . "(-> \"%s\" #?(:clj clojure.repl/source :cljs cljs.repl/source))")
+                          (arglists . "(try (-> (symbol \"%s\") #?(:clj (->> str clojure.core/read-string clojure.core/resolve clojure.core/meta :arglists) :cljs (->> cljs.core/resolve cljs.core/meta :arglists))) #?(:clj (catch Throwable _ nil) :cljs (catch :default _ nil)))")
+                          (apropos  . "(let [inf-clojure-dummy-val \"%s\"] #?(:clj (doseq [var (sort (clojure.repl/apropos inf-clojure-dummy-val))] (println (str var))) :cljs (cljs.repl/apropos inf-clojure-dummy-val))")
+                          (ns-vars . "(-> %s #?(:clj clojure.repl/dir :cljs cljs.repl/dir))")
+                          (set-ns . "(in-ns '%s)")
+                          (macroexpand . "(-> '%s #?(:clj clojure.core/macroexpand :cljs cljs.core/macroexpand))")
+                          (macroexpand-1 . "(-> '%s #?(:clj clojure.core/macroexpand-1 :cljs cljs.core/macroexpand-1))")))))
 
 (defvar-local inf-clojure-repl-type nil
   "Symbol to define your REPL type.


### PR DESCRIPTION
When using repls that transition from clj to cljs (via things like embedded shadow-cljs) it's nice to have commands that work for both instead of trying to change the repl type.

**Replace this placeholder text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines][1]
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!

[1]: https://github.com/clojure-emacs/inf-clojure/blob/master/.github/CONTRIBUTING.md
